### PR TITLE
Increase delay to 60 seconds

### DIFF
--- a/lib/battery-status-view.coffee
+++ b/lib/battery-status-view.coffee
@@ -29,7 +29,7 @@ class BatteryStatusView extends HTMLDivElement
   update: ->
     setInterval =>
         @updateStatus()
-      , 1000
+      , 60000
 
   updateStatus: ->
     # fetch battery percentage and charge status and update the view


### PR DESCRIPTION
We work for hours and we most of the time don't want to see the "instant" battery results and it doesn't change much in 1 minute.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cmd-johnson/atom-battery-status/5)

<!-- Reviewable:end -->
