### PR TITLE
Added battery remaining time

### DIFF
--- a/lib/battery-status-view.coffee
+++ b/lib/battery-status-view.coffee
@@ -55,14 +55,15 @@ class BatteryStatusView extends HTMLDivElement
     batteryStatus.getChargeStatus (batteryStats) =>
       if batteryStats.length >= 1
         batStats = batteryStats[0]
-        @updateStatusText batStats.powerLevel
+        @updateStatusText batStats.powerLevel, batStats.remaining
         @updateStatusIcon batStats.powerLevel, batStats.chargeStatus
 
-  updateStatusText: (percentage) ->
+  updateStatusText: (percentage, remaining) ->
     if percentage?
       # display charge of the first battery in percent (no multi battery support
       # as of now)
       @statusText.textContent = "#{percentage}%"
+      @statusText.textContent += " (#{remaining})" if remaining?
     else
       @statusText.textContent = 'error'
       console.warn "Battery Status: invalid charge value: #{percentage}"

--- a/lib/battery-status-view.coffee
+++ b/lib/battery-status-view.coffee
@@ -7,6 +7,7 @@ class BatteryStatusView extends HTMLDivElement
   frontIcon: null
   statusIconContainer: null
   statusText: null
+  showRemainingTime: true
   pollingInterval: 60000
 
   initialize: (@statusBar) ->
@@ -63,7 +64,9 @@ class BatteryStatusView extends HTMLDivElement
       # display charge of the first battery in percent (no multi battery support
       # as of now)
       @statusText.textContent = "#{percentage}%"
-      @statusText.textContent += " (#{remaining})" if remaining?
+      if @showRemainingTime && remaining? && remaining.hours? && remaining.minutes?
+        minutes = ("0" + remaining.minutes).substr(-2)
+        @statusText.textContent += " (#{remaining.hours}:#{minutes})"
     else
       @statusText.textContent = 'error'
       console.warn "Battery Status: invalid charge value: #{percentage}"
@@ -119,6 +122,10 @@ class BatteryStatusView extends HTMLDivElement
     else
       @statusText.setAttribute 'style', 'display: none;'
 
+  setShowRemainingTime: (showRemainingTime) ->
+    @showRemainingTime = showRemainingTime
+    @updateStatus()
+
   setOnlyShowInFullscreen: (onlyShowInFullscreen) ->
     if onlyShowInFullscreen
       @classList.add 'hide-outside-fullscreen'
@@ -130,6 +137,5 @@ class BatteryStatusView extends HTMLDivElement
       pollingInterval = Math.max(pollingInterval, 1)
       @pollingInterval = 1000 * pollingInterval
       @startPolling()
-
 
 module.exports = document.registerElement('battery-status', prototype: BatteryStatusView.prototype)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -11,13 +11,18 @@ module.exports = BatteryStatus =
       type: 'boolean'
       default: true
       description: 'Display the charge percentage next to the charge icon'
-    onlyShowWhileInFullscreen:
+    showRemainingTime:
       order: 2
+      type: 'boolean'
+      default: true
+      description: 'Display the estimated remaining time until the battery is (dis-)charged (currently only available on macOS)'
+    onlyShowWhileInFullscreen:
+      order: 3
       type: 'boolean'
       default: false
       description: 'Display the status item only while in full-screen mode'
     pollingInterval:
-      order: 3
+      order: 4
       type: 'integer'
       default: 60
       description: 'How many seconds should be waited between updating the battery\'s status'
@@ -37,6 +42,9 @@ module.exports = BatteryStatus =
     @disposables = new CompositeDisposable
     @disposables.add atom.config.observe 'battery-status.showPercentage', (showPercentage) =>
       @batteryStatusView?.setShowPercentage showPercentage
+
+    @disposables.add atom.config.observe 'battery-status.showRemainingTime', (showRemainingTime) =>
+      @batteryStatusView?.setShowRemainingTime showRemainingTime
 
     @disposables.add atom.config.observe 'battery-status.onlyShowWhileInFullscreen', (onlyShowInFullscreen) =>
       @batteryStatusView?.setOnlyShowInFullscreen onlyShowInFullscreen


### PR DESCRIPTION
Using https://github.com/cmd-johnson/node-power-info/pull/5, shows the remaining time in parentheses besides the battery % if available.