### PR TITLE
Do not show time available when battery is full

### DIFF
--- a/lib/battery-status-view.coffee
+++ b/lib/battery-status-view.coffee
@@ -77,7 +77,7 @@ class BatteryStatusView extends HTMLDivElement
       # display charge of the first battery in percent (no multi battery support
       # as of now)
       @statusText.textContent = "#{battery.powerLevel.toString().split('.')[0]}%"
-      if @showRemainingTime && battery.isTimeAvailable
+      if @showRemainingTime && battery.isTimeAvailable && battery.chargeStatus != "full"
         remainingMinutes = ('0' + battery.remainingTimeMinutes).slice -2
         @statusText.textContent += " (#{battery.remainingTimeHours}:#{remainingMinutes})"
     else


### PR DESCRIPTION
When charging on macOS, the battery status helpfully displays the time remaining until fully charged. However, when the battery had been charged to 100%, the status would keep displaying `(0:00)`, which looked a bit unfortunate.

<img width="501" alt="before" src="https://user-images.githubusercontent.com/3198913/47808213-2861a980-dd3e-11e8-9f5c-0f99cd94f591.png">

This pull request changes this behaviour such that the time remaining is no longer shown when fully charged.

<img width="501" alt="after" src="https://user-images.githubusercontent.com/3198913/47808293-53e49400-dd3e-11e8-86c8-52b738039a26.png">